### PR TITLE
Fix reading of Uint8Array slices from offset arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbuffers_reflection",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Library for performing reflection on Flatbuffers in typescript",
   "license": "Apache-2.0",
   "repository": {

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -444,7 +444,9 @@ export class Parser {
       let result: (number | BigInt)[] | Uint8Array;
       // If the vector is a byte vector, we can return a slice into the buffer
       if (isUByteVector) {
-        result = new Uint8Array(table.bb.bytes().buffer, baseOffset, numElements);
+        result = new Uint8Array(table.bb.bytes().buffer,
+                                table.bb.bytes().byteOffset + baseOffset,
+                                numElements);
       } else {
         result = [];
         for (let ii = 0; ii < numElements; ++ii) {


### PR DESCRIPTION
When we introduced being able to read Uint8Array slices from a ByteBuffer, we incorrectly handled if the backing buffer was offset.