### PR TITLE
 Consistent line endings for typescript builds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "./src/index.ts"],
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/esm"
+    "outDir": "./dist/esm",
+    "newLine": "lf"
   }
 }


### PR DESCRIPTION
Avoids hash errors when building the same code on windows vs mac/linux