### PR TITLE
Remove `src` from files listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "module": "dist/esm/index.js",
   "main": "dist/cjs/index.js",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",


### PR DESCRIPTION
Removes the `src` folder from the files listing such that these files are not installed