### PR TITLE
Deserialize fields in id order

### DIFF
--- a/src/reflection.test.ts
+++ b/src/reflection.test.ts
@@ -100,6 +100,23 @@ describe("parseReflectionSchema", () => {
       expect(parser.readScalar(fieldTable, "padding", true)).toBe(0);
     }
   });
+  it("reads fields in order of id", () => {
+    const reflectionSchemaBuffer: Buffer = readFileSync(`${__dirname}/vendor/gen/reflection.bfbs`);
+    const reflectionSchemaByteBuffer: ByteBuffer = new ByteBuffer(reflectionSchemaBuffer);
+    const schema = Schema.getRootAsSchema(reflectionSchemaByteBuffer);
+    const parser = new Parser(schema);
+    const table = Table.getRootTable(reflectionSchemaByteBuffer);
+    const schemaObject = parser.toObject(table);
+    expect(Object.keys(schemaObject)).toEqual([
+      "objects",
+      "enums",
+      "file_ident",
+      "file_ext",
+      "root_table",
+      "services",
+      "fbs_files",
+    ]);
+  });
   it("converts uint8 vectors to uint8arrays", () => {
     const builder = new Builder();
     const data = ByteVector.createDataVector(builder, [1, 2, 3]);

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -247,11 +247,19 @@ export class Parser {
     const lambdas: Record<string, any> = {};
     const schema = this.getType(typeIndex);
     const numFields = schema.fieldsLength();
-    for (let ii = 0; ii < numFields; ++ii) {
-      const field = schema.fields(ii);
+
+    // Sort fields by ID so the resulting object is built with fields in this order
+    const sortedFields: reflection.Field[] = [];
+    for (let i = 0; i < numFields; ++i) {
+      const field = schema.fields(i);
       if (field === null) {
-        throw new Error("Malformed schema: field at index " + ii + " not populated.");
+        throw new Error("Malformed schema: field at index " + i + " not populated.");
       }
+      sortedFields.push(field);
+    }
+    sortedFields.sort((a, b) => a.id() - b.id());
+
+    for (const field of sortedFields) {
       const fieldType = field.type();
       if (fieldType === null) {
         throw new Error('Malformed schema: "type" field of Field not populated.');

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -248,7 +248,8 @@ export class Parser {
     const schema = this.getType(typeIndex);
     const numFields = schema.fieldsLength();
 
-    // Sort fields by ID so the resulting object is built with fields in this order
+    // Sort fields by ID so the resulting object is built with fields in this order.
+    // This tends to correspond with the order in the original .fbs (unless ids were specified manually).
     const sortedFields: reflection.Field[] = [];
     for (let i = 0; i < numFields; ++i) {
       const field = schema.fields(i);

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -253,7 +253,7 @@ export class Parser {
     for (let i = 0; i < numFields; ++i) {
       const field = schema.fields(i);
       if (field === null) {
-        throw new Error("Malformed schema: field at index " + i + " not populated.");
+        throw new Error(`Malformed schema: field at index ${i} not populated.`);
       }
       sortedFields.push(field);
     }


### PR DESCRIPTION
Sort fields by `id` before deserializing to maintain id order. (When `flatc` generates a reflection schema object it seems to put the fields in alphabetical order, as mentioned in a [particularly unspecific comment](https://github.com/google/flatbuffers/blob/150644d7f4d030a0629c564fd90dc3becab77636/reflection/reflection.fbs#L95).)

Question: it seems like `id` isn't technically a _required_ field in the reflection schema. Are there any "normal" situations where id would be unset (or default to 0)? I guess since this is a stable sort, it probably doesn't matter too much, but just wondering if there are any known cases where this could result in a weird sort order.