### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,15 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        # `yarn publish` does not support --provenance
-        run: npm publish flatbuffers_reflection-*.tgz --provenance --access public
+        run: |
+          PACKAGE_VERSION="refs/tags/v$(cat package.json | jq .version)"
+          if [ ${{ github.ref }} != "${PACKAGE_VERSION}" ]; then
+             echo "::error::The package.json version does not match the git tag used for this release."
+             echo "${PACKAGE_VERSION}"
+             echo ${{ github.ref }}
+             exit 1
+          fi
+          # `yarn publish` does not support --provenance
+          npm publish flatbuffers_reflection-*.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbuffers_reflection",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "description": "Library for performing reflection on Flatbuffers in typescript",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
I accidentally created a v1.0.0 tag for the 0.1.0 release. I have no particular reason not to create a 1.0 version, so just do so now to ensure consistency in version numbers and to ensure that the versions are monotonically increasing everywhere.

Additionally, add a check to the publish step prior to actually publishing.