### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbuffers_reflection",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Library for performing reflection on Flatbuffers in typescript",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Probably should've bumped the minor version with the unions update as well, but since this adds a new readFieldLambda() to the interface, may as well bump it now.