### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbuffers_reflection",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Library for performing reflection on Flatbuffers in typescript",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This contains some fixes for union parsing and updates us to prefer using `undefined` over `null` when indicating that a value is not populated.